### PR TITLE
Fix circle-text-body-alignment

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -156,5 +156,9 @@ export default {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 </style>


### PR DESCRIPTION
This fixes the circle-text-body-alignment on Firefox at least. Otherwise stuff like this happens:

![afbeelding](https://user-images.githubusercontent.com/743155/50970839-d1691500-14e2-11e9-94d9-9568e9d74a11.png)
