### PR TITLE
Watch `progress` and `fill` to fit Vue style.

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -88,6 +88,12 @@ export default {
     .on('circle-inited', function(event){
       renderCircleBody(this, (vm.progress/vm.scale));
       vm.$emit('vue-circle-init', event);
+      vm.$watch('progress', (nv) => {
+        vm.updateProgress(nv)
+      })
+      vm.$watch('fill', (nv) => {
+        vm.updateFill(nv)
+      })
     })
     .circleProgress({
       value: this.convertedProgress(vm.progress),


### PR DESCRIPTION
Thanks for this JQuery plugin wrapper.

I found the default behavior of this component is a little confusing for developer, that developer must call method in this component via `$refs` to update the `progress`, that's quite strange for a Vue plugin. So I add a watch for `progress` and user should need not to call `updateProgress()` manually anymore in most scenarios, and this behavior should be more like a Vue plugin which is reactive to the changes of data model.

**I didn't build dist in this PR because I encountered [the error of "You are using the runtime-only build of Vue..."](https://github.com/vrajroham/vue-circle-progress/issues/15)** (so you may need to check the issue #15 first for the dist...) 
At last I `import VueCircle from 'vue2-circle-progress/src/index.vue'` directly and it works great.